### PR TITLE
Catch the NoClassDefFoundError if it's thrown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
-* (nothing yet)
+* Fixed a bug for Java 11 compatibility
 
 ## 2.1.4
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/LocalProjectPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/LocalProjectPipelineExtensionDetector.java
@@ -86,7 +86,7 @@ public class LocalProjectPipelineExtensionDetector extends APipelineExtensionDet
 
 			try {
 				clazz = Class.forName( classname );
-			} catch( ClassNotFoundException e ) {
+			} catch( ClassNotFoundException | NoClassDefFoundError e ) {
 				failures.put( classname, e );
 				continue;
 			}


### PR DESCRIPTION
Summary
==============================

See #89. It looks like newer versions of the JRE throw a different exception for `Class::forName`. It used to be `ClassNotFoundException` but Java 11 appears to be throwing the same exception but wrapped in a `NoClassDefFoundError`. 

Additional Details
==============================

n/a

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [ ] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
