### PR TITLE
Scan classpaths for extensions only once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## Unreleased
 
+* Scan classpaths for extensions only once
 * Fixed a bug for Java 11 compatibility
 
 ## 2.1.5

--- a/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
+++ b/src/main/groovy/com/homeaway/devtools/jenkins/testing/JenkinsPipelineSpecification.groovy
@@ -1104,35 +1104,38 @@ public abstract class JenkinsPipelineSpecification extends Specification {
 			}
 		}
 		
-		APipelineExtensionDetector classpath_scanner = new WholeClasspathPipelineExtensionDetector()
-		
-		PIPELINE_STEPS = classpath_scanner.getPipelineSteps(Optional.<String>empty())
-		
-		Set<String> symbols = classpath_scanner.getSymbols(Optional.<String>empty())
-		Set<String> global_variables = classpath_scanner.getGlobalVariables(Optional.<String>empty())
-		Set<String> shared_library_variables = getSharedLibraryVariables()
-		
-		PIPELINE_SYMBOLS.addAll( symbols )
-		PIPELINE_SYMBOLS.addAll( global_variables )
-		PIPELINE_SYMBOLS.addAll( shared_library_variables )
-		
-		Set<Class<?>> classes = new LocalProjectPipelineExtensionDetector()
-		.getClassesOfTypeInPackage(
-			Object.class,
-			Optional.<String>empty())
-		
-		// This class will behave differently and _not_ forward pipeline step invocations directly to the appropriately-named mock. 
-		classes.remove(PipelineVariableImpersonator.class)
-		
-		// instrument CpsScript, which we know we'll be using.
-		classes.add( CpsScript.class )
-		
-		// exclude all interfaces - nobody will be able to call them, so they don't need to be instrumented.
-		// any implementation will be a real, detected class.
-		classes = classes.findAll { ! it.isInterface() }
-		
-		// and publish that list of classes
-		DEFAULT_TEST_CLASSES.addAll( classes )
+		// Scan classpaths for extensions only once
+		if(PIPELINE_STEPS.isEmpty()) {
+			APipelineExtensionDetector classpath_scanner = new WholeClasspathPipelineExtensionDetector()
+
+			PIPELINE_STEPS = classpath_scanner.getPipelineSteps(Optional.<String> empty())
+
+			Set<String> symbols = classpath_scanner.getSymbols(Optional.<String> empty())
+			Set<String> global_variables = classpath_scanner.getGlobalVariables(Optional.<String> empty())
+			Set<String> shared_library_variables = getSharedLibraryVariables()
+
+			PIPELINE_SYMBOLS.addAll(symbols)
+			PIPELINE_SYMBOLS.addAll(global_variables)
+			PIPELINE_SYMBOLS.addAll(shared_library_variables)
+
+			Set<Class<?>> classes = new LocalProjectPipelineExtensionDetector()
+					.getClassesOfTypeInPackage(
+							Object.class,
+							Optional.<String> empty())
+
+			// This class will behave differently and _not_ forward pipeline step invocations directly to the appropriately-named mock.
+			classes.remove(PipelineVariableImpersonator.class)
+
+			// instrument CpsScript, which we know we'll be using.
+			classes.add(CpsScript.class)
+
+			// exclude all interfaces - nobody will be able to call them, so they don't need to be instrumented.
+			// any implementation will be a real, detected class.
+			classes = classes.findAll { !it.isInterface() }
+
+			// and publish that list of classes
+			DEFAULT_TEST_CLASSES.addAll(classes)
+		}
 	}
 	
 	/**


### PR DESCRIPTION
See details in #98

Summary
==============================

Scan classpaths for extensions only once not per test suite class.

Additional Details
==============================

#98 

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [x] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
