### PR TITLE
Fix master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 
 * Fixed a bug for Java 11 compatibility
+* Changed Jenkins Maven repo URL from http:// to https://
 
 ## 2.1.5
 

--- a/examples/helper-script/pom.xml
+++ b/examples/helper-script/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/examples/shared-library/pom.xml
+++ b/examples/shared-library/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/examples/whole-pipeline/pom.xml
+++ b/examples/whole-pipeline/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
+		</repository>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<name>Jenkins Repo</name>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
Summary
==============================

Maven now disables `http` repos by default. See more information in [this](https://stackoverflow.com/questions/67833372/getting-blocked-mirror-for-repositories-maven-error-even-after-adding-mirrors) StackOverflow question:

> Maven now disables all insecure http://* mirrors by default. Here is explanation from maven mainteners: http://maven.apache.org/docs/3.8.1/release-notes.html#cve-2021-26291
>> _More and more repositories use HTTPS nowadays, but this hasn’t always been the case. This means that Maven Central contains POMs with custom repositories that refer to a URL over HTTP. This makes downloads via such repository a target for a MITM attack. At the same time, developers are probably not aware that for some downloads an insecure URL is being used. Because uploaded POMs to Maven Central are immutable, a change for Maven was required. To solve this, we extended the mirror configuration with parameter, and we added a new external:http:* mirror selector (like existing external:*), meaning “any external URL using HTTP”. The decision was made to block such external HTTP repositories by default: this is done by providing a mirror in the conf/settings.xml blocking insecure HTTP external URLs._


This changes the Jenkins repo from `http` to `https`. 


Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [ ] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [ ] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
