### PR TITLE
Fix local class scanning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 build.log
 **/*.versionsBackup
 .DS_Store
+logdir*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 * Fixed a bug for Java 11 compatibility
 * Changed Jenkins Maven repo URL from http:// to https://
+* The LocalProjectPipelineExtensionDetectorSpec#getClassesOfTypeInPackage method now finds classes that are 
+  descendants of `java.lang.Object` but aren't direct subtypes. 
 
 ## 2.1.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ## Unreleased
 
 * Fixed a bug for Java 11 compatibility
+* Changed Jenkins Maven repo URL from http:// to https://
 
 ## 2.1.5
 

--- a/examples/helper-script/pom.xml
+++ b/examples/helper-script/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/examples/shared-library/pom.xml
+++ b/examples/shared-library/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/examples/whole-pipeline/pom.xml
+++ b/examples/whole-pipeline/pom.xml
@@ -15,12 +15,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
 		</repository>
 		<repository>
 			<id>jenkins-public</id>
 			<name>Jenkins Public</name>
-			<url>http://repo.jenkins-ci.org/public</url>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -277,12 +277,6 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.reflections</groupId>
-			<artifactId>reflections</artifactId>
-			<version>0.9.12</version>
-		</dependency>
-
-		<dependency>
 			<groupId>io.github.classgraph</groupId>
 			<artifactId>classgraph</artifactId>
 			<version>4.8.104</version>
@@ -424,10 +418,10 @@
 
 		<!-- 'parallel' step comes from workflow-cps -->
 
-		<!-- 
+		<!--
 			for mocking the Jenkins singleton outside Spock
 			Only done to verify that IF that is done properly, THEN
-			jenkins-spock can use that object 
+			jenkins-spock can use that object
 		-->
 		<dependency>
 			<groupId>org.mockito</groupId>
@@ -441,7 +435,6 @@
 	<build>
 		<pluginManagement>
 			<plugins>
-
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-assembly-plugin</artifactId>
@@ -482,7 +475,7 @@
 					<artifactId>maven-dependency-plugin</artifactId>
 					<configuration>
 						<usedDependencies>
-							<!-- these will be used by Groovy code, when the included test utilities 
+							<!-- these will be used by Groovy code, when the included test utilities
 								are spun up during a test run -->
 							<usedDependency>cglib:cglib-nodep</usedDependency>
 							<usedDependency>junit:junit</usedDependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,12 @@
 		<repository>
 			<id>jenkins-releases</id>
 			<name>Jenkins Releases</name>
-			<url>http://repo.jenkins-ci.org/releases</url>
+			<url>https://repo.jenkins-ci.org/releases</url>
+		</repository>
+		<repository>
+			<id>repo.jenkins-ci.org</id>
+			<name>Jenkins Repo</name>
+			<url>https://repo.jenkins-ci.org/public</url>
 		</repository>
 	</repositories>
 

--- a/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
+++ b/src/main/java/com/homeaway/devtools/jenkins/testing/WholeClasspathPipelineExtensionDetector.java
@@ -25,10 +25,11 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
 
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ScanResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.github.classgraph.ClassGraph;
 
 /**
  * Search through classes in the entire classpath for Jenkins Pipeline extensions.
@@ -44,14 +45,19 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 	@Override
 	public Set<Class<?>> getClassesOfTypeInPackage(Class<?> _supertype, Optional<String> _package) {
 
+		List<String> classnames;
+		try (
+			ScanResult scanResult = new ClassGraph()
+				.acceptPackages(_package.orElse(""))
+				.scan()
+		) {
+			classnames = scanResult
+				.getAllClasses()
+				.filter(ci -> ci.extendsSuperclass(_supertype.getName()))
+				.getNames();
+		}
+
 		Set<Class<?>> classes = new HashSet<>();
-
-		List<String> classnames = new ClassGraph()
-			.enableAnnotationInfo()
-			.enableClassInfo()
-			.acceptPackages(_package.orElse(""))
-			.scan().getAllStandardClasses().getNames();
-
 		HashMap<String, Throwable> failures = new HashMap<>();
 
 		for(String classname: classnames) {
@@ -60,7 +66,7 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 
 			try {
 				clazz = Class.forName( classname );
-			} catch( ClassNotFoundException e ) {
+			} catch( ClassNotFoundException | NoClassDefFoundError e ) {
 				failures.put( classname, e );
 				continue;
 			} catch( Throwable t ) {
@@ -94,15 +100,21 @@ public class WholeClasspathPipelineExtensionDetector extends APipelineExtensionD
 	@Override
 	public Set<Class<?>> getClassesWithAnnotationOfTypeInPackage( Class<? extends Annotation> _annotation, Class<?> _supertype, Optional<String> _package) {
 
+		List<String> annotated_classnames;
+		try (
+			ScanResult scanResult = new ClassGraph()
+				.acceptPackages(_package.orElse(""))
+				.enableAnnotationInfo()
+				.scan();
+		) {
+			annotated_classnames = scanResult
+				.getClassesWithAnnotation(_annotation.getName())
+				.filter(ci -> ci.extendsSuperclass(_supertype.getName()))
+				.getNames();
+		}
+
 		Set<Class<?>> annotated_classes = new HashSet<>();
-
 		HashMap<String, Throwable> failures = new HashMap<>();
-
-		List<String> annotated_classnames = new ClassGraph()
-			.enableAnnotationInfo()
-			.enableClassInfo()
-			.acceptPackages(_package.orElse(""))
-			.scan().getClassesWithAnnotation( _annotation.getName() ).getNames();
 
 		for(String classname: annotated_classnames) {
 

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/LocalProjectPipelineExtensionDetectorSpec.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/LocalProjectPipelineExtensionDetectorSpec.groovy
@@ -1,0 +1,18 @@
+package com.homeaway.devtools.jenkins.testing
+
+import com.homeaway.devtools.jenkins.testing.functions.ScriptToTest
+
+class LocalProjectPipelineExtensionDetectorSpec extends JenkinsPipelineSpecification {
+
+    def "LocalProjectPipelineExtensionDetectorSpec should detect classes that aren't direct subtypes of java-lang-Object" () {
+        when:
+        Set<Class<?>> classes = new LocalProjectPipelineExtensionDetector()
+            .getClassesOfTypeInPackage(
+                Object.class,
+                Optional.<String>empty()
+            )
+
+        then:
+        classes.contains(ScriptToTest)
+    }
+}

--- a/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ScriptToTest.groovy
+++ b/src/test/groovy/com/homeaway/devtools/jenkins/testing/functions/ScriptToTest.groovy
@@ -1,0 +1,5 @@
+package com.homeaway.devtools.jenkins.testing.functions
+
+def helloWorld(String argument) {
+    echo argument
+}


### PR DESCRIPTION
**Note**: The branch for this PR is rebased on top of the branch for the #110 because of the importance of fixing the master build process. 

Summary
==============================
There are a few changes in this PR:
1. Jenkins allows shared libraries to be written as a script, in addition to fully qualified class. The superclass of a script is `groovy.lang.Script`, whereas the superclass of a regular class is whatever the class extends (or `java.lang.Object` if it doesn't extend a class). 

    The `LocalProjectPipelineExtensionDetector` class scans for classes in the project to instrument in the `getClassesOfTypeInPackage` method by using the Reflections package. It scans for classes that extend Object. Reflections, however, does not supporting scanning for classes that extend a class but are not direct subtypes of the same class. So the `getClassesOfTypeInPackage` method misses all Jenkins scripts that are a part of the shared library. 

    An easy solution to this would be to also scan for classes that extend `groovy.lang.Script`. However, it is also perfectly valid for Jenkins shared libraries classes to extend other Jenkins shared library classes. The solution here is to use a class scanner that supports searching for classes that are descendants of a class. 

2. According to [this](https://github.com/ExpediaGroup/jenkins-spock/pull/99#issuecomment-839263658) comment, a `ScanResult` should be assigned within a try-with-resources, so I have made that change in the Local detector and the WholeClasspath detector.  

3. I found another Java 11+ compatibility issue (not catching `NoClassDefFoundError` exception) and fixed it.

Checklist
==============================

Testing
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have manually verified that my code changes do the right thing.
* [x] I have run the tests and verified that my changes do not introduce any regressions.
* [x] I have written unit tests to verify that my code changes do the right thing and to protect my code against regressions

Documentation
-------------------------

(Remove this checklist and replace it with "N/A - no code changes" if this PR does not modify source code)

* [x] I have updated the "Unreleased" section of `CHANGELOG.md` with a brief description of my changes.
* [x] I have updated code comments - both GroovyDoc/JavaDoc-style comments and inline comments - where appropriate.
* [x] I have read `CONTRIBUTING.md` and have followed its guidance.
